### PR TITLE
For accessToken to be exposed needed to pass param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Google Auth plugin for capacitor.",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/web.ts
+++ b/src/web.ts
@@ -36,10 +36,12 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
 
       const googleUser = await gapi.auth2.getAuthInstance().signIn();
 
+      const authResponse = googleUser.getAuthResponse(true);
+
       const user = {
         authentication: {
-          accessToken: googleUser.getAuthResponse().access_token,
-          idToken: googleUser.getAuthResponse().id_token
+          accessToken: authResponse.access_token,
+          idToken: authResponse.id_token
         }
       }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -35,7 +35,6 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     return new Promise(async (resolve) => {
 
       const googleUser = await gapi.auth2.getAuthInstance().signIn();
-
       const authResponse = googleUser.getAuthResponse(true);
 
       const user = {


### PR DESCRIPTION
I've tried the new version and it didn't work because of the fact that we need to pass true to 

> googleUser.getAuthResponse(true);

otherwise, it won't return accessToken 😕 

Sorry to bother you less I've even bumped the version to 0.0.5, it would mean very much to me if you could accept this and push a new version of the package to npm.

Thank you.

      