### PR TITLE
Add Sign out.

### DIFF
--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -5,4 +5,5 @@
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(GoogleAuth, "GoogleAuth",
            CAP_PLUGIN_METHOD(signIn, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(signOut, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -34,6 +34,12 @@ public class GoogleAuth: CAPPlugin {
             }
         }
     }
+
+    @objc
+    func signOut(_ call: CAPPluginCall) {
+        GIDSignIn.sharedInstance().signOut();
+        call.success();
+    }
     
     @objc
     func handleOpenUrl(_ notification: Notification) {


### PR DESCRIPTION
This PR ads a signOut method, only implemented on iOS so far, not sure how to implement on web, and Android isn't done yet so I'd rather not touch the code for that.

This is useful for https://github.com/CodetrixStudio/CapacitorGoogleAuth/issues/5 for the reasons mentioned there.