### PR TITLE
Lock GoogleSignIn version to something compatible with this lib

### DIFF
--- a/CodetrixStudioCapacitorGoogleAuth.podspec
+++ b/CodetrixStudioCapacitorGoogleAuth.podspec
@@ -10,6 +10,6 @@
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '11.0'
     s.dependency 'Capacitor'
-    s.dependency 'GoogleSignIn'
+    s.dependency 'GoogleSignIn', '< 5'
     s.static_framework = true
   end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -6,7 +6,7 @@ target 'Plugin' do
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 
-  pod 'GoogleSignIn'
+  pod 'GoogleSignIn', '< 5'
   
 end
 


### PR DESCRIPTION
Version 5.0 of the google sign in lib includes breaking changes. For now it's probably best to pin the old version, till this library can be updated. 