### PR TITLE
Add support for forceAuthCode on iOS and Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ local.properties
 
 # Signing files
 .signing/
+
+# Android
+/android/.idea
+/android/android.iml

--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ Provide configuration in root `capacitor.config.json`
   "plugins": {
     "GoogleAuth": {
       "scopes": ["profile", "email"],
-      "serverClientId": "xxxxxx-xxxxxxxxxxxxxxxxxx.apps.googleusercontent.com"
+      "serverClientId": "xxxxxx-xxxxxxxxxxxxxxxxxx.apps.googleusercontent.com",
+      "forceCodeForRefreshToken" : true
     }
   }
 }
 
 ```
+
+Note : `forceCodeForRefreshToken` force user to select email address to regenerate AuthCode used to get a valid refreshtoken (work on iOS and Android) (This is used for offline access and serverside handling)

--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -27,10 +27,17 @@ public class GoogleAuth extends Plugin {
   @Override
   public void load() {
     String clientId = this.getContext().getString(R.string.server_client_id);
+    Boolean forceCodeForRefreshToken = false;
+
+    Boolean forceRefreshToken = (Boolean) getConfigValue("forceCodeForRefreshToken");
+    if (forceRefreshToken != null) {
+      forceCodeForRefreshToken = forceRefreshToken;
+    }
+
     GoogleSignInOptions.Builder googleSignInBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-      .requestIdToken(clientId)
-      .requestServerAuthCode(clientId)
-      .requestEmail();
+            .requestIdToken(clientId)
+            .requestServerAuthCode(clientId, forceCodeForRefreshToken)
+            .requestEmail();
 
     try {
       JSONArray scopeArray = (JSONArray) getConfigValue("scopes");

--- a/demo/capacitor.config.json
+++ b/demo/capacitor.config.json
@@ -8,7 +8,8 @@
   "plugins": {
     "GoogleAuth": {
       "scopes": ["profile", "email"],
-      "serverClientId": "744254868856-6j8dflcgq0tiqt0b506b61etukcq3rdm.apps.googleusercontent.com"
+      "serverClientId": "744254868856-6j8dflcgq0tiqt0b506b61etukcq3rdm.apps.googleusercontent.com",
+      "forceCodeForRefreshToken" : true
     }
   }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -29,7 +29,7 @@ public class GoogleAuth: CAPPlugin {
             googleSignIn.scopes = scopes;
         }
 
-		if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshToken") as? [Bool] {
+        if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshToken") as? [Bool] {
             forceAuthCode = forceAuthCodeConfig;
         }
 		

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Capacitor
 import GoogleSignIn
-
+​
 /**
  * Please read the Capacitor iOS Plugin Development Guide
  * here: https://capacitor.ionicframework.com/docs/plugins/ios
@@ -10,45 +10,45 @@ import GoogleSignIn
 public class GoogleAuth: CAPPlugin {
     var signInCall: CAPPluginCall?
     let googleSignIn: GIDSignIn = GIDSignIn.sharedInstance();
-	let forceAuthCode: Bool
-	
+    var forceAuthCode: Bool = false;
+    
     public override func load() {
         guard let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") else {return}
         guard let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] else {return}
         guard let clientId = dict["CLIENT_ID"] as? String else {return}
-
+​
         googleSignIn.clientID = clientId;
         googleSignIn.delegate = self;
         googleSignIn.presentingViewController = bridge.viewController;
-
+​
         if let serverClientId = getConfigValue("serverClientId") as? String {
             googleSignIn.serverClientID = serverClientId;
         }
-
+​
         if let scopes = getConfigValue("scopes") as? [String] {
             googleSignIn.scopes = scopes;
         }
-
-        if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshToken") as? [Bool] {
+​
+        if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshToken") as? Bool {
             forceAuthCode = forceAuthCodeConfig;
         }
-		
+        
         NotificationCenter.default.addObserver(self, selector: #selector(handleOpenUrl(_ :)), name: Notification.Name(CAPNotifications.URLOpen.name()), object: nil);
     }
-
+​
     @objc
     func signIn(_ call: CAPPluginCall) {
         signInCall = call;
-
+​
         DispatchQueue.main.async {
-            if self.googleSignIn.hasPreviousSignIn() && !forceAuthCode {
+            if self.googleSignIn.hasPreviousSignIn() && !self.forceAuthCode {
                 self.googleSignIn.restorePreviousSignIn();
             } else {
                 self.googleSignIn.signIn();
             }
         }
     }
-
+​
     @objc
     func refresh(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
@@ -56,13 +56,13 @@ public class GoogleAuth: CAPPlugin {
                 call.error("User not logged in.");
                 return
             }
-
+​
             self.googleSignIn.currentUser.authentication.getTokensWithHandler { (authentication, error) in
                 guard let authentication = authentication else {
                     call.error(error?.localizedDescription ?? "Something went wrong.");
                     return;
                 }
-
+​
                 let authenticationData: [String: Any] = [
                     "accessToken": authentication.accessToken,
                     "idToken": authentication.idToken,
@@ -72,7 +72,7 @@ public class GoogleAuth: CAPPlugin {
             }
         }
     }
-
+​
     @objc
     func signOut(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
@@ -80,22 +80,22 @@ public class GoogleAuth: CAPPlugin {
         }
         call.success();
     }
-
+​
     @objc
     func handleOpenUrl(_ notification: Notification) {
         guard let object = notification.object as? [String: Any] else {
             print("There is no object on handleOpenUrl");
             return;
         }
-
+​
         guard let url = object["url"] as? URL else {
             print("There is no url on handleOpenUrl");
             return;
         }
-
+​
         googleSignIn.handle(url);
     }
-
+​
     func processCallback(user: GIDGoogleUser) {
         var userData: [String: Any] = [
             "authentication": [
@@ -110,22 +110,22 @@ public class GoogleAuth: CAPPlugin {
             "id": user.userID,
             "name": user.profile.name
         ];
-
+​
         if let imageUrl = user.profile.imageURL(withDimension: 100)?.absoluteString {
             userData["imageUrl"] = imageUrl;
         }
-
+​
         signInCall?.success(userData);
     }
 }
-
+​
 extension GoogleAuth: GIDSignInDelegate {
     public func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error!) {
         if let error = error {
             signInCall?.error(error.localizedDescription);
             return;
         }
-
+​
         processCallback(user: user);
     }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -10,7 +10,8 @@ import GoogleSignIn
 public class GoogleAuth: CAPPlugin {
     var signInCall: CAPPluginCall?
     let googleSignIn: GIDSignIn = GIDSignIn.sharedInstance();
-
+	let forceAuthCode: Bool
+	
     public override func load() {
         guard let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") else {return}
         guard let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] else {return}
@@ -28,6 +29,10 @@ public class GoogleAuth: CAPPlugin {
             googleSignIn.scopes = scopes;
         }
 
+		if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshToken") as? [Bool] {
+            forceAuthCode = forceAuthCodeConfig;
+        }
+		
         NotificationCenter.default.addObserver(self, selector: #selector(handleOpenUrl(_ :)), name: Notification.Name(CAPNotifications.URLOpen.name()), object: nil);
     }
 
@@ -36,7 +41,7 @@ public class GoogleAuth: CAPPlugin {
         signInCall = call;
 
         DispatchQueue.main.async {
-            if self.googleSignIn.hasPreviousSignIn() {
+            if self.googleSignIn.hasPreviousSignIn() && !forceAuthCode {
                 self.googleSignIn.restorePreviousSignIn();
             } else {
                 self.googleSignIn.signIn();


### PR DESCRIPTION
I've tested it on Android and iOS and works great.
You can then close this issue https://github.com/CodetrixStudio/CapacitorGoogleAuth/issues/44

More informations here for Android : 
https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInOptions.Builder#public-googlesigninoptions.builder-requestserverauthcode-string-serverclientid,-boolean-forcecodeforrefreshtoken

and here for iOS : 
https://stackoverflow.com/questions/42434887/google-sign-in-server-auth-code-nil-ios