### PR TITLE
Auto last login, easier setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ Make sure you have `GoogleService-Info.plist` with `CLIENT_ID`
 Add `REVERSED_CLIENT_ID` as url scheme to `Info.plist`
 
 ### Android
-Inside your `strings.xml`
-```xml
-<resources>
-  <string name="server_client_id">Your Web Client Key</string>
-</resources>
-```
 
 Import package inside your `MainActivity`
 ```java


### PR DESCRIPTION
This does two things:
- If an account was previously connected to the app, automatically use it when calling `signIn`. Previously, it did the same thing, but the whole pipeline with the GUI was executed as well resulting in quick appearing and disappearing UI bits.
- On Android, using the client ID from capacitor config, instead of using strings.xml. Did I miss something? Why isn't it like this in the first place?

Thank you