### PR TITLE
[Capacitor v3] use 'registerPlugin' func instead of using registerWebPlugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,27 @@
 {
   "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "2.1.1",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@capacitor/android": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-1.5.1.tgz",
-      "integrity": "sha512-dubGu+Im5uqdkLBX9c0azGF1v3AY1HTlWxZmjn7qN48AXJL3woxCi4TVv2MEXJRxgfQq5Aunqu6rsmF/bDaOHw==",
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.0.0-beta.2.tgz",
+      "integrity": "sha512-lDanxEnbzXGh7C8CumqIDJ/c1jJng+CGHQ/WMLhJ1qxGADCHFrFv7Hh4PSIljYhAkDkln6bQjtq7zOOtz6yYYw==",
       "dev": true
     },
     "@capacitor/core": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.5.1.tgz",
-      "integrity": "sha512-3ncsiM+G1w4/osKbtPXGfHGOp/A1WKein1EVDX3O151aqjNf44F+n/zweZG1XvtOmY4AHNaQcHYO/s9nMOmPOw==",
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.0-beta.2.tgz",
+      "integrity": "sha512-BTYVh4LMTY9lnT1qMwyAg8ursJCQyLilhZO8Uw1GFdNFKPCrTKwabzzOCM02EzhxZJDLNCVpoBufdBRlgEzz9Q==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.1.0"
       }
     },
     "@capacitor/ios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-1.5.1.tgz",
-      "integrity": "sha512-6b8o/U87KIRWj3OLT+RrStTS56FWF7/dJkFe75XS5PBZPlWl8dKB3MUb3oKpWX5E7Y105Yo8CA/fKOSk8QQzsg==",
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.0.0-beta.2.tgz",
+      "integrity": "sha512-tUXJ/xjzhB3kW9HEGowaaOhPztiB/KFchG7g4PlreBLZX0wIa0l1+Q+w9GTGuDF8hBZnRBxFNXECsPisYMpfZQ==",
       "dev": true
     },
     "@types/gapi": {
@@ -40,9 +40,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "typescript": {
       "version": "3.4.5",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "author": "CodetrixStudio",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^3.0.0-beta.2"
   },
   "devDependencies": {
-    "@capacitor/android": "latest",
-    "@capacitor/ios": "latest",
+    "@capacitor/android": "^3.0.0-beta.2",
+    "@capacitor/ios": "^3.0.0-beta.2",
     "@types/gapi": "0.0.36",
     "@types/gapi.auth2": "0.0.50",
     "typescript": "^3.2.4"

--- a/src/web.ts
+++ b/src/web.ts
@@ -132,8 +132,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
   }
 }
 
-const GoogleAuth = new GoogleAuthWeb();
+const GoogleAuth = registerPlugin('GoogleAuth', { web: new GoogleAuthWeb() });
 
 export { GoogleAuth };
 
-registerPlugin('GoogleAuth', { web: GoogleAuth });

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,4 +1,4 @@
-import { WebPlugin } from '@capacitor/core';
+import { registerPlugin, WebPlugin } from '@capacitor/core';
 import { GoogleAuthPlugin } from './definitions';
 import { User, Authentication } from './user';
 
@@ -136,5 +136,4 @@ const GoogleAuth = new GoogleAuthWeb();
 
 export { GoogleAuth };
 
-import { registerWebPlugin } from '@capacitor/core';
-registerWebPlugin(GoogleAuth);
+registerPlugin('GoogleAuth', { web: GoogleAuth });


### PR DESCRIPTION
use 'registerPlugin' func instead of using registerWebPlugin


registerWebPlugin function is deprecated.

This PR can be breaking changes for v2. 