### PR TITLE
refactor(web): registering plugins and lazy loading

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,4 +4,7 @@ export interface GoogleAuthPlugin {
   signIn(): Promise<User>;
   refresh(): Promise<Authentication>;
   signOut(): Promise<any>;
+
+  /** Init hook for load gapi and init plugin */
+  init(): void;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,11 +1,5 @@
 import { Authentication, User } from "./user";
 
-declare module "@capacitor/core" {
-  interface PluginRegistry {
-    GoogleAuth: GoogleAuthPlugin;
-  }
-}
-
 export interface GoogleAuthPlugin {
   signIn(): Promise<User>;
   refresh(): Promise<Authentication>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,10 @@
+import { registerPlugin } from '@capacitor/core';
+import { GoogleAuthWeb } from './web';
+import type { GoogleAuthPlugin } from './definitions';
+
+const GoogleAuth = registerPlugin<GoogleAuthPlugin>('GoogleAuth', {
+  web: new GoogleAuthWeb(),
+});
+
 export * from './definitions';
-export * from './web';
+export { GoogleAuth };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 import { registerPlugin } from '@capacitor/core';
-import { GoogleAuthWeb } from './web';
 import type { GoogleAuthPlugin } from './definitions';
 
 const GoogleAuth = registerPlugin<GoogleAuthPlugin>('GoogleAuth', {
-  web: new GoogleAuthWeb(),
+  web: () => import('./web').then(m => new m.GoogleAuthWeb()),
 });
 
 export * from './definitions';

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,4 +1,4 @@
-import { registerPlugin, WebPlugin } from '@capacitor/core';
+import { WebPlugin } from '@capacitor/core';
 import { GoogleAuthPlugin } from './definitions';
 import { User, Authentication } from './user';
 
@@ -135,8 +135,3 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     return user;
   }
 }
-
-const GoogleAuth = registerPlugin('GoogleAuth', { web: new GoogleAuthWeb() });
-
-export { GoogleAuth };
-

--- a/src/web.ts
+++ b/src/web.ts
@@ -24,7 +24,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     });
   }
 
-  initialize() {
+  loadScript() {
     var head = document.getElementsByTagName('head')[0];
     var script = document.createElement('script');
     script.type = 'text/javascript';
@@ -42,7 +42,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     this.gapiLoaded = new Promise(resolve => {
       // HACK: Relying on window object, can't get property in gapi.load callback
       (window as any).gapiResolve = resolve;
-      this.initialize();
+      this.loadScript();
     });
 
     this.addUserChangeListener();

--- a/src/web.ts
+++ b/src/web.ts
@@ -22,17 +22,6 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
       name: 'GoogleAuth',
       platforms: ['web']
     });
-
-    if (!this.webConfigured)
-      return;
-
-    this.gapiLoaded = new Promise(resolve => {
-      // HACK: Relying on window object, can't get property in gapi.load callback
-      (window as any).gapiResolve = resolve;
-      this.initialize();
-    });
-
-    this.addUserChangeListener();
   }
 
   initialize() {
@@ -44,6 +33,19 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     script.onload = this.platformJsLoaded;
     script.src = 'https://apis.google.com/js/platform.js';
     head.appendChild(script);
+  }
+
+  init(){
+    if (!this.webConfigured)
+      return;
+
+    this.gapiLoaded = new Promise(resolve => {
+      // HACK: Relying on window object, can't get property in gapi.load callback
+      (window as any).gapiResolve = resolve;
+      this.initialize();
+    });
+
+    this.addUserChangeListener();
   }
 
   platformJsLoaded() {

--- a/src/web.ts
+++ b/src/web.ts
@@ -18,10 +18,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
   }
 
   constructor() {
-    super({
-      name: 'GoogleAuth',
-      platforms: ['web']
-    });
+    super();
   }
 
   loadScript() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,14 +7,14 @@
       "dom",
       "es2015"
     ],
-    "module": "es2015",
+    "module": "ESNext",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "dist/esm",
     "sourceMap": true,
-    "target": "es2015"
+    "target": "es2017"
   },
   "files": [
     "src/index.ts"


### PR DESCRIPTION
1. Refactor registering plugins by spec doc 
https://capacitorjs.com/docs/updating/plugins/3-0#registering-plugins

2. move constructor init to method hook `init` for manually controlling loading on document ready

    example for vue:
    
    ```ts
    import { defineComponent, onMounted } from 'vue'
    import { GoogleAuth } from '@reslear/capacitor-google-auth'
    
    export default defineComponent({
      setup() {
        onMounted(() => {
          GoogleAuth.init()
        })
        
        const logIn = async () => {
          const response = await GoogleAuth.signIn()
          console.log(response)
        }
        
        return {
          logIn
        }
      }
    })
    ```
