### PR TITLE
refactor(iOS): migrate to GoogleSignIn v6

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -6,7 +6,7 @@ target 'Plugin' do
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 
-  pod 'GoogleSignIn', '~> 5.0.2'
+  pod 'GoogleSignIn', '~> 6.0.1'
 
 end
 


### PR DESCRIPTION
🏁 Starting iOS migration to GoogleSignIn v6

💪 Pros:
+ mac m1 emulator ready
+ now open source https://github.com/google/GoogleSignIn-iOS
+ fixed bugs 
+ more api
+ actual version

👎 Cons:
- no compatible with old api 
- no compatible `scopes`, but have complete pr https://github.com/google/GoogleSignIn-iOS/pull/30

🚧 Working progress:
- [x] load
- [x] signIn
- [ ] refresh
- [ ] signOut
- [ ] handleOpenUrl
- [ ] processCallback
- [ ]  GIDSignInDelegate

📦 swift example: https://github.com/paraches/GoogleSignIn6_SwiftUI

😃 i'am jun on Swift, NEED HELP for migration, write test, and need basic check my code, thank you!!!

👥 @parveenkhtkr @ctrengove @NLueg @Yuripetusko @leo6104 @thibaud-sanchez  and other friends Welcome :)