### PR TITLE
refactor: `init` only for web, no check platform

### DIFF
--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -59,6 +59,11 @@ public class GoogleAuth extends Plugin {
     googleSignInClient = GoogleSignIn.getClient(this.getContext(), googleSignInOptions);
   }
 
+  @PluginMethod
+  public void init(PluginCall call) {
+      call.unimplemented();
+  }
+
   @PluginMethod()
   public void signIn(PluginCall call) {
     saveCall(call);

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -7,4 +7,5 @@ CAP_PLUGIN(GoogleAuth, "GoogleAuth",
            CAP_PLUGIN_METHOD(signIn, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(refresh, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(signOut, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(init, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -35,6 +35,11 @@ public class GoogleAuth: CAPPlugin {
     }
 
     @objc
+    func init(_ call: CAPPluginCall) {
+        call.unimplemented("Not available on iOS")
+    }
+
+    @objc
     func signIn(_ call: CAPPluginCall) {
         signInCall = call;
         DispatchQueue.main.async {


### PR DESCRIPTION
no need check platform: 
```ts
const platform = Capacitor.getPlatform()

if (platform === "web") {
  GoogleAuth.init();
}
```

only 
```ts
GoogleAuth.init();
```

TODO:
- [x] iOS
- [x] Android
