### PR TITLE
Update ios to GoogleSignIn 6.0.1 Pod

### DIFF
--- a/CodetrixStudioCapacitorGoogleAuth.podspec
+++ b/CodetrixStudioCapacitorGoogleAuth.podspec
@@ -10,6 +10,6 @@
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
-    s.dependency 'GoogleSignIn', '~> 5.0.2'
+    s.dependency 'GoogleSignIn', '~> 6.0.1'
     s.static_framework = true
   end

--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -27,13 +27,11 @@ public class GoogleAuth extends Plugin {
 
   @Override
   public void load() {
-    String clientId = this.getContext().getString(R.string.server_client_id);
-    boolean forceCodeForRefreshToken = false;
+    String clientId = getConfig().getString("androidClientId",
+      getConfig().getString("clientId",
+        this.getContext().getString(R.string.server_client_id)));
 
-    Boolean forceRefreshToken = (Boolean) getConfigValue("forceCodeForRefreshToken");
-    if (forceRefreshToken != null) {
-      forceCodeForRefreshToken = forceRefreshToken;
-    }
+    boolean forceCodeForRefreshToken = getConfig().getBoolean("forceCodeForRefreshToken", false);
 
     GoogleSignInOptions.Builder googleSignInBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(clientId)
@@ -43,17 +41,13 @@ public class GoogleAuth extends Plugin {
       googleSignInBuilder.requestServerAuthCode(clientId, true);
     }
 
-    try {
-      JSONArray scopeArray = (JSONArray) getConfigValue("scopes");
-      Scope[] scopes = new Scope[scopeArray.length() - 1];
-      Scope firstScope = new Scope(scopeArray.getString(0));
-      for (int i = 1; i < scopeArray.length(); i++) {
-        scopes[i - 1] = new Scope(scopeArray.getString(i));
-      }
-      googleSignInBuilder.requestScopes(firstScope, scopes);
-    } catch (JSONException e) {
-      e.printStackTrace();
+    String[] scopeArray = getConfig().getArray("scopes", new String[] {});
+    Scope[] scopes = new Scope[scopeArray.length - 1];
+    Scope firstScope = new Scope(scopeArray[0]);
+    for (int i = 1; i < scopeArray.length; i++) {
+      scopes[i - 1] = new Scope(scopeArray[i]);
     }
+    googleSignInBuilder.requestScopes(firstScope, scopes);
 
     GoogleSignInOptions googleSignInOptions = googleSignInBuilder.build();
     googleSignInClient = GoogleSignIn.getClient(this.getContext(), googleSignInOptions);

--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -151,7 +151,6 @@
 				50ADFF84201F53D600D50D53 /* Frameworks */,
 				50ADFF85201F53D600D50D53 /* Headers */,
 				50ADFF86201F53D600D50D53 /* Resources */,
-				D5C0AD06C6436A87FC8525B9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -171,7 +170,6 @@
 				50ADFF8E201F53D600D50D53 /* Frameworks */,
 				50ADFF8F201F53D600D50D53 /* Resources */,
 				CDBD6291F99392856E80ED8A /* [CP] Embed Pods Frameworks */,
-				954E831AAF3D05995C5AB46F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -262,24 +260,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		954E831AAF3D05995C5AB46F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PluginTests/Pods-PluginTests-resources.sh",
-				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSignIn.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PluginTests/Pods-PluginTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		AB5B3E54B4E897F32C2279DA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -310,6 +290,7 @@
 				"${BUILT_PRODUCTS_DIR}/AppAuth/AppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleSignIn/GoogleSignIn.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -318,28 +299,11 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleSignIn.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PluginTests/Pods-PluginTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D5C0AD06C6436A87FC8525B9 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Plugin/Pods-Plugin-resources.sh",
-				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSignIn.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Plugin/Pods-Plugin-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -13,15 +13,18 @@ public class GoogleAuth: CAPPlugin {
     var forceAuthCode: Bool = false;
 
     public override func load() {
-        guard let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") else {
-            print("GoogleService-Info.plist not found");
-            return;
-        }
-        guard let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] else {return}
-        guard let clientId = dict["CLIENT_ID"] as? String else {return}
-        googleSignIn.clientID = clientId;
         googleSignIn.delegate = self;
         googleSignIn.presentingViewController = bridge?.viewController;
+        
+        if let clientId = getConfigValue("clientId") as? String {
+            googleSignIn.clientID = clientId;
+        }
+        else if let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+           let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject],
+           let clientId = dict["CLIENT_ID"] as? String {
+            googleSignIn.clientID = clientId;
+        }
+
         if let serverClientId = getConfigValue("serverClientId") as? String {
             googleSignIn.serverClientID = serverClientId;
         }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -16,7 +16,10 @@ public class GoogleAuth: CAPPlugin {
         googleSignIn.delegate = self;
         googleSignIn.presentingViewController = bridge?.viewController;
         
-        if let clientId = getConfigValue("clientId") as? String {
+        if let clientId = getConfigValue("iosClientId") as? String {
+            googleSignIn.clientID = clientId;
+        }
+        else if let clientId = getConfigValue("clientId") as? String {
             googleSignIn.clientID = clientId;
         }
         else if let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -8,35 +8,32 @@ import GoogleSignIn
  */
 @objc(GoogleAuth)
 public class GoogleAuth: CAPPlugin {
-    var signInCall: CAPPluginCall?
-    let googleSignIn: GIDSignIn = GIDSignIn.sharedInstance();
+    var signInCall: CAPPluginCall!
+    var googleSignIn: GIDSignIn!;
+    var googleSignInConfiguration: GIDConfiguration!;
     var forceAuthCode: Bool = false;
+    var scopes: [String]?;
 
+    
     public override func load() {
-        googleSignIn.delegate = self;
-        googleSignIn.presentingViewController = bridge?.viewController;
+        googleSignIn = GIDSignIn.sharedInstance;
         
-        if let clientId = getConfigValue("iosClientId") as? String {
-            googleSignIn.clientID = clientId;
-        }
-        else if let clientId = getConfigValue("clientId") as? String {
-            googleSignIn.clientID = clientId;
-        }
-        else if let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
-           let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject],
-           let clientId = dict["CLIENT_ID"] as? String {
-            googleSignIn.clientID = clientId;
+        let clientId = getClientIdValue();
+        let serverClientId = getServerClientIdValue();
+        
+        guard let clientId = clientId else {
+            NSLog("no client id found in config")
+            return;
         }
 
-        if let serverClientId = getConfigValue("serverClientId") as? String {
-            googleSignIn.serverClientID = serverClientId;
-        }
-        if let scopes = getConfigValue("scopes") as? [String] {
-            googleSignIn.scopes = scopes;
-        }
+        googleSignInConfiguration = GIDConfiguration.init(clientID: clientId, serverClientID: serverClientId)
+
+        scopes = getConfigValue("scopes") as? [String];
+        
         if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshToken") as? Bool {
             forceAuthCode = forceAuthCodeConfig;
         }
+
         NotificationCenter.default.addObserver(self, selector: #selector(handleOpenUrl(_ :)), name: Notification.Name(CAPNotifications.URLOpen.name()), object: nil);
     }
 
@@ -47,7 +44,13 @@ public class GoogleAuth: CAPPlugin {
             if self.googleSignIn.hasPreviousSignIn() && !self.forceAuthCode {
                 self.googleSignIn.restorePreviousSignIn();
             } else {
-                self.googleSignIn.signIn();
+                self.googleSignIn.signIn(with: self.googleSignInConfiguration, presenting: self.bridge!.viewController!) {  user, error in
+                    if let error = error {
+                        self.signInCall?.reject(error.localizedDescription);
+                        return;
+                    }
+                    self.processCallback(user: user!);
+                };
             }
         }
     }
@@ -59,7 +62,7 @@ public class GoogleAuth: CAPPlugin {
                 call.reject("User not logged in.");
                 return
             }
-            self.googleSignIn.currentUser.authentication.getTokensWithHandler { (authentication, error) in
+            self.googleSignIn.currentUser!.authentication.do { (authentication, error) in
                 guard let authentication = authentication else {
                     call.reject(error?.localizedDescription ?? "Something went wrong.");
                     return;
@@ -94,6 +97,29 @@ public class GoogleAuth: CAPPlugin {
         }
         googleSignIn.handle(url);
     }
+    
+    
+    func getClientIdValue() -> String? {
+        if let clientId = getConfigValue("iosClientId") as? String {
+            return clientId;
+        }
+        else if let clientId = getConfigValue("clientId") as? String {
+            return clientId;
+        }
+        else if let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+                let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject],
+                let clientId = dict["CLIENT_ID"] as? String {
+            return clientId;
+        }
+        return nil;
+    }
+    
+    func getServerClientIdValue() -> String? {
+        if let serverClientId = getConfigValue("serverClientId") as? String {
+            return serverClientId;
+        }
+        return nil;
+    }
 
     func processCallback(user: GIDGoogleUser) {
         var userData: [String: Any] = [
@@ -103,25 +129,15 @@ public class GoogleAuth: CAPPlugin {
                 "refreshToken": user.authentication.refreshToken
             ],
             "serverAuthCode": user.serverAuthCode,
-            "email": user.profile.email,
-            "familyName": user.profile.familyName,
-            "givenName": user.profile.givenName,
+            "email": user.profile?.email,
+            "familyName": user.profile?.familyName,
+            "givenName": user.profile?.givenName,
             "id": user.userID,
-            "name": user.profile.name
+            "name": user.profile?.name
         ];
-        if let imageUrl = user.profile.imageURL(withDimension: 100)?.absoluteString {
+        if let imageUrl = user.profile?.imageURL(withDimension: 100)?.absoluteString {
             userData["imageUrl"] = imageUrl;
         }
         signInCall?.resolve(userData);
-    }
-}
-
-extension GoogleAuth: GIDSignInDelegate {
-    public func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error!) {
-        if let error = error {
-            signInCall?.reject(error.localizedDescription);
-            return;
-        }
-        processCallback(user: user);
     }
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -6,7 +6,7 @@ target 'Plugin' do
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 
-  pod 'GoogleSignIn', '~> 5.0.2'
+  pod 'GoogleSignIn', '~> 6.0.1'
 
 end
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,29 +1,25 @@
 PODS:
-  - AppAuth (1.3.0):
-    - AppAuth/Core (= 1.3.0)
-    - AppAuth/ExternalUserAgent (= 1.3.0)
-  - AppAuth/Core (1.3.0)
-  - AppAuth/ExternalUserAgent (1.3.0)
-  - Capacitor (1.5.1):
-    - CapacitorCordova (= 1.5.1)
-  - CapacitorCordova (1.5.1)
-  - GoogleSignIn (5.0.2):
-    - AppAuth (~> 1.2)
+  - AppAuth (1.4.0):
+    - AppAuth/Core (= 1.4.0)
+    - AppAuth/ExternalUserAgent (= 1.4.0)
+  - AppAuth/Core (1.4.0)
+  - AppAuth/ExternalUserAgent (1.4.0)
+  - Capacitor (3.0.1):
+    - CapacitorCordova
+  - CapacitorCordova (3.0.1)
+  - GoogleSignIn (6.0.1):
+    - AppAuth (~> 1.4)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GTMAppAuth (1.0.0):
-    - AppAuth/Core (~> 1.0)
-    - GTMSessionFetcher (~> 1.1)
-  - GTMSessionFetcher (1.3.1):
-    - GTMSessionFetcher/Full (= 1.3.1)
-  - GTMSessionFetcher/Core (1.3.1)
-  - GTMSessionFetcher/Full (1.3.1):
-    - GTMSessionFetcher/Core (= 1.3.1)
+  - GTMAppAuth (1.2.2):
+    - AppAuth/Core (~> 1.4)
+    - GTMSessionFetcher/Core (~> 1.5)
+  - GTMSessionFetcher/Core (1.6.1)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - GoogleSignIn (~> 5.0.2)
+  - GoogleSignIn (~> 6.0.1)
 
 SPEC REPOS:
   trunk:
@@ -39,13 +35,13 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  AppAuth: 73574f3013a1e65b9601a3ddc8b3158cce68c09d
-  Capacitor: 373adb05f4591a70c22adfe979b5a443ac1e9b0a
-  CapacitorCordova: 169792fba40cc325d70b3cbca49d0563acdf5924
-  GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
-  GTMAppAuth: 4deac854479704f348309e7b66189e604cf5e01e
-  GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
+  AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
+  Capacitor: 92088387144015b95e369bd7840e8ef28b8fe9f3
+  CapacitorCordova: 624ae0d33d61b554eda6823da8ea6c3e5170f646
+  GoogleSignIn: 1b0c4ec33a6fe282f4fa35d8ac64263230ddaf36
+  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
+  GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
 
-PODFILE CHECKSUM: 26646079fafcf11562258f66ca17008384d1890a
+PODFILE CHECKSUM: 0f3f70de2469d6ef87a4f55c3a96868777b79b2e
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codetrix-studio/capacitor-google-auth",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^3.0.1",


### PR DESCRIPTION
Before v6 you could not run an app using GoogleSignIn on a Simulator on an M1/Apple Silicon Mac. 