### PR TITLE
refactor(android): separate messages for signin exception

### DIFF
--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -43,6 +43,10 @@ public class GoogleAuth extends Plugin {
   private final static String FIELD_TOKEN_EXPIRES_IN = "expires_in";
   private final static String FIELD_ACCESS_TOKEN = "accessToken";
   private final static String FIELD_TOKEN_EXPIRES = "expires";
+
+  // see https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInStatusCodes#SIGN_IN_CANCELLED
+  private final static int SIGN_IN_CANCELLED = 12501;
+
   public static final int KAssumeStaleTokenSec = 60;
 
   private GoogleSignInClient googleSignInClient;
@@ -121,7 +125,11 @@ public class GoogleAuth extends Plugin {
         }
       });
     } catch (ApiException e) {
-      call.reject("Something went wrong", e);
+      if (SIGN_IN_CANCELLED == e.getStatusCode()) {
+        call.reject("The user canceled the sign-in flow.", "" + e.getStatusCode());
+      } else {
+        call.reject("Something went wrong", "" + e.getStatusCode());
+      }
     }
   }
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -58,7 +58,7 @@ public class GoogleAuth: CAPPlugin {
                 
                 self.googleSignIn.signIn(with: self.googleSignInConfiguration, presenting: presentingVc) { user, error in
                     if let error = error {
-                        self.signInCall?.reject(error.localizedDescription);
+                        self.signInCall?.reject(error.localizedDescription, "\(error._code)");
                         return;
                     }
                     if self.additionalScopes.count > 0 {


### PR DESCRIPTION
In order to properly react to the situation where a user cancels the flow, I added the status code to the Android implementation. The iOS returns the same message in case the user cancels the flow: `"The user canceled the sign-in flow."`

For me this is the last step in order to make this plugin a full replacement for the [cordova-plugin-googleplus](https://github.com/EddyVerbruggen/cordova-plugin-googleplus) which also returns the status code.