### PR TITLE
ios return user when restorePreviousSignIn()

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -52,7 +52,13 @@ public class GoogleAuth: CAPPlugin {
         signInCall = call;
         DispatchQueue.main.async {
             if self.googleSignIn.hasPreviousSignIn() && !self.forceAuthCode {
-                self.googleSignIn.restorePreviousSignIn();
+                self.googleSignIn.restorePreviousSignIn() { user, error in
+                if let error = error {
+                    self.signInCall?.reject(error.localizedDescription);
+                    return;
+                }
+                self.resolveSignInCallWith(user: user!)
+                }
             } else {
                 let presentingVc = self.bridge!.viewController!;
                 


### PR DESCRIPTION
Subsequent calls of GoogleAuth.signIn() now return the user object. This is useful when restoring a previous sign in. I use this to fetch a new token that I can then submit to Amazon Cognito Federated Identity pools.

Also added error handling.

This fixes #69 as `let googleUser = await Plugins.GoogleAuth.signIn(null) as any;` hangs due to nothing being returned.

My first PR :)