### PR TITLE
Refresh for GoogleAuth Android

### DIFF
--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -135,7 +135,22 @@ public class GoogleAuth extends Plugin {
 
   @PluginMethod()
   public void refresh(final PluginCall call) {
-    call.reject("I don't know how to refresh token on Android");
+    Task<GoogleSignInAccount> task = googleSignInClient.silentSignIn();
+    if (task.isSuccessful()) {
+      extractUserFromAccount(task.getResult(), call);
+    }
+    task.addOnCompleteListener(task1 -> {
+      try {
+        extractUserFromAccount(task1.getResult(ApiException.class), call);
+      } catch (ApiException e) {
+        // You can get from apiException.getStatusCode() the detailed error code
+        // e.g. GoogleSignInStatusCodes.SIGN_IN_REQUIRED means user needs to take
+        // explicit action to finish sign-in;
+        // Please refer to GoogleSignInStatusCodes Javadoc for details
+        e.printStackTrace();
+        call.reject("Something went wrong with silent sign in", e);
+      }
+    });
   }
 
   @PluginMethod()


### PR DESCRIPTION
Added solution to refresh GoogleAuth, recommended to call silentSignIn prior to each API call to your application server.

ref: https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInClient#public-taskgooglesigninaccount-silentsignin