### PR TITLE
Custom scopes for different requirements (Android)

### DIFF
--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -51,23 +51,15 @@ public class GoogleAuth extends Plugin {
 
   private GoogleSignInClient googleSignInClient;
 
-  @Override
-  public void load() {
-    String clientId = getConfig().getString("androidClientId",
-      getConfig().getString("clientId",
-        this.getContext().getString(R.string.server_client_id)));
-
-    boolean forceCodeForRefreshToken = getConfig().getBoolean("forceCodeForRefreshToken", false);
-
+  public void loadSignInClient (String clientId, boolean forceCodeForRefreshToken, String[] scopeArray) {
     GoogleSignInOptions.Builder googleSignInBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(clientId)
-            .requestEmail();
+      .requestIdToken(clientId)
+      .requestEmail();
 
     if (forceCodeForRefreshToken) {
       googleSignInBuilder.requestServerAuthCode(clientId, true);
     }
 
-    String[] scopeArray = getConfig().getArray("scopes", new String[] {});
     Scope[] scopes = new Scope[scopeArray.length - 1];
     Scope firstScope = new Scope(scopeArray[0]);
     for (int i = 1; i < scopeArray.length; i++) {
@@ -78,6 +70,9 @@ public class GoogleAuth extends Plugin {
     GoogleSignInOptions googleSignInOptions = googleSignInBuilder.build();
     googleSignInClient = GoogleSignIn.getClient(this.getContext(), googleSignInOptions);
   }
+
+  @Override
+  public void load() {}
 
   @PluginMethod()
   public void signIn(PluginCall call) {
@@ -146,6 +141,31 @@ public class GoogleAuth extends Plugin {
 
   @PluginMethod()
   public void initialize(final PluginCall call) {
+    // get data from config
+    String configClientId = getConfig().getString("androidClientId",
+      getConfig().getString("clientId",
+        this.getContext().getString(R.string.server_client_id)));
+    boolean configForceCodeForRefreshToken = getConfig().getBoolean("forceCodeForRefreshToken", false);
+    // need to get this as string so as to standardize with data from plugin call
+    String configScopeArray = getConfig().getString("scopes", new String());
+
+    // get client id from plugin call, fallback to be client id from config
+    String clientId = call.getData().getString("clientId", configClientId);
+    // get forceCodeForRefreshToken from call, fallback to be from config
+    boolean forceCodeForRefreshToken = call.getData().getBoolean("grantOfflineAccess", configForceCodeForRefreshToken);
+    // get scopes from call, fallback to be from config
+    String scopesStr = call.getData().getString("scopes", configScopeArray);
+    // replace all the symbols from parsing array as string
+    // leaving only scopes delimited by commas
+    String replacedScopesStr = scopesStr
+      .replaceAll("[\"\\[\\] ]", "")
+      // this is for scopes that are in the form of a url
+      .replace("\\", "");
+
+    // scope to be in the form of an array
+    String[] scopeArray = replacedScopesStr.split(",");
+
+    loadSignInClient(clientId, forceCodeForRefreshToken, scopeArray);
     call.resolve();
   }
 


### PR DESCRIPTION
### Having custom scopes whenever the function initializes

I have an app whereby there are different scope requirements for different functions of the app so as to not request for excessive scopes from the user.

For example,
1. the part whereby I just need the user to log in, the scope of `['email', 'profile']` is sufficient.
2. the part whereby I need access to the user's calendar, I need the scope of `['email', 'profile', 'https://www.googleapis.com/auth/calendar']`

There is currently no convenient way to do this in the app as it takes the scope from the capacitor config (i.e capacitor.config.json)

So in this implementation, I am taking the data from the `GoogleAuth.initialize` function as it's used on the web and accessing the data inside Android for reusability

In JS, initialize GoogleAuth same as web
```
import { GoogleAuth } from '@codetrix-studio/capacitor-google-auth';

// use hook after platform dom ready
GoogleAuth.initialize({
  clientId: 'CLIENT_ID.apps.googleusercontent.com',
  scopes: ['profile', 'email'],
  grantOfflineAccess: true,
});
```

In GoogleAuth.java, I moved the entire load function to another function. So it becomes as follows
```
public void loadSignInClient (String clientId, boolean forceCodeForRefreshToken, String[] scopeArray) {
    GoogleSignInOptions.Builder googleSignInBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
      .requestIdToken(clientId)
      .requestEmail();

    if (forceCodeForRefreshToken) {
      googleSignInBuilder.requestServerAuthCode(clientId, true);
    }

    Scope[] scopes = new Scope[scopeArray.length - 1];
    Scope firstScope = new Scope(scopeArray[0]);
    for (int i = 1; i < scopeArray.length; i++) {
      scopes[i - 1] = new Scope(scopeArray[i]);
    }
    googleSignInBuilder.requestScopes(firstScope, scopes);

    GoogleSignInOptions googleSignInOptions = googleSignInBuilder.build();
    googleSignInClient = GoogleSignIn.getClient(this.getContext(), googleSignInOptions);
  }

 @Override
 public void load() {}
```

Then I call the `loadSignInClient` from `initialize`, while getting the custom data from the plugin call, with the data inside capacitor.json as fallback

### Note
I don't have any clue how to change a string ('["email", "profile"]') to a valid string[] easily in Java. So do update the code if anyone has a better idea on how to do it

