### PR TITLE
Fix #272, #55

### DIFF
--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -63,7 +63,6 @@ public class GoogleAuth extends Plugin {
 
     GoogleSignInOptions.Builder googleSignInBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(clientId)
-            .requestServerAuthCode(clientId)
             .requestEmail();
 
     if (forceCodeForRefreshToken) {

--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -61,6 +61,7 @@ public class GoogleAuth extends Plugin {
 
     GoogleSignInOptions.Builder googleSignInBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(clientId)
+            .requestServerAuthCode(clientId)
             .requestEmail();
 
     if (forceCodeForRefreshToken) {

--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -36,6 +36,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.OnFailureListener;
 
 @CapacitorPlugin()
 public class GoogleAuth extends Plugin {
@@ -141,8 +143,19 @@ public class GoogleAuth extends Plugin {
 
   @PluginMethod()
   public void signOut(final PluginCall call) {
-    googleSignInClient.signOut();
-    call.resolve();
+    googleSignInClient.signOut()
+      .addOnSuccessListener(getActivity(), new OnSuccessListener<Void>() {
+        @Override
+          public void onSuccess(Void aVoid) {
+            call.resolve();
+          }
+      })
+      .addOnFailureListener(getActivity(), new OnFailureListener() {
+        @Override
+          public void onFailure(Exception e) {
+            call.reject("Sign out failed", e);
+          }
+      });
   }
 
   @PluginMethod()


### PR DESCRIPTION
This fixes the Android `signOut()` method resolving before the sign-out task is completed.

This causes a race condition where the user is actually logged out but on the next login attempt, the previous account is used instead of showing the account picker.