### PR TITLE
Port android test stubs to capacitor 5, and exclude them from npm package

### DIFF
--- a/android/src/androidTest/java/com/getcapacitor/android/ExampleInstrumentedTest.java
+++ b/android/src/androidTest/java/com/getcapacitor/android/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.getcapacitor.android;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,7 +19,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() throws Exception {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         assertEquals("com.getcapacitor.android", appContext.getPackageName());
     }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "dist/",
     "ios/",
     "android/",
+    "!android/src/androidTest",
+    "!android/src/test",
     "CodetrixStudioCapacitorGoogleAuth.podspec"
   ],
   "keywords": [


### PR DESCRIPTION
I ran into an issue after upgrading to capacitor 5: I could not build my project anymore, because the tests from this project (which I depend on) would not compile. A recent upgrade to androidx moved some stuff around. Furthermore, the error is in a test stub, which I of course, as a consumer, do not need.

This PR: 
- fixes the test stub so it compiles
- excludes the android tests from the npm package
- Note: I did *not* exclude the iOS tests, as I do not have a Mac at hand, so I cannot verify it could cause issues to exclude the tests