### PR TITLE
Bump ios GoogleSignIn to 6.2.4 (Allows requesting scopes during initial signIn)

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -62,24 +62,12 @@ public class GoogleAuth: CAPPlugin {
             } else {
                 let presentingVc = self.bridge!.viewController!;
                 
-                self.googleSignIn.signIn(with: self.googleSignInConfiguration, presenting: presentingVc) { user, error in
+                self.googleSignIn.signIn(with: self.googleSignInConfiguration, presenting: presentingVc, hint: nil, additionalScopes: self.additionalScopes) { user, error in
                     if let error = error {
                         self.signInCall?.reject(error.localizedDescription, "\(error._code)");
                         return;
                     }
-                    if self.additionalScopes.count > 0 {
-                        // requesting additional scopes in GoogleSignIn-iOS SDK 6.0 requires that you sign the user in and then request additional scopes,
-                        // there's no method to include the additional scopes in the initial sign in request
-                        self.googleSignIn.addScopes(self.additionalScopes, presenting: presentingVc) { user, error in
-                            if let error = error {
-                                self.signInCall?.reject(error.localizedDescription);
-                                return;
-                            }
-                            self.resolveSignInCallWith(user: user!);
-                        }
-                    } else {
-                        self.resolveSignInCallWith(user: user!);
-                    }
+                    self.resolveSignInCallWith(user: user!);
                 };
             }
         }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -8,7 +8,7 @@ target 'Plugin' do
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
 
-  pod 'GoogleSignIn', '~> 6.0.1'
+  pod 'GoogleSignIn', '~> 6.2.4'
 
 end
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,25 +1,26 @@
 PODS:
-  - AppAuth (1.4.0):
-    - AppAuth/Core (= 1.4.0)
-    - AppAuth/ExternalUserAgent (= 1.4.0)
-  - AppAuth/Core (1.4.0)
-  - AppAuth/ExternalUserAgent (1.4.0)
-  - Capacitor (3.0.1):
+  - AppAuth (1.6.2):
+    - AppAuth/Core (= 1.6.2)
+    - AppAuth/ExternalUserAgent (= 1.6.2)
+  - AppAuth/Core (1.6.2)
+  - AppAuth/ExternalUserAgent (1.6.2):
+    - AppAuth/Core
+  - Capacitor (5.0.4):
     - CapacitorCordova
-  - CapacitorCordova (3.0.1)
-  - GoogleSignIn (6.0.1):
-    - AppAuth (~> 1.4)
-    - GTMAppAuth (~> 1.0)
-    - GTMSessionFetcher/Core (~> 1.1)
-  - GTMAppAuth (1.2.2):
-    - AppAuth/Core (~> 1.4)
-    - GTMSessionFetcher/Core (~> 1.5)
-  - GTMSessionFetcher/Core (1.6.1)
+  - CapacitorCordova (5.0.4)
+  - GoogleSignIn (6.2.4):
+    - AppAuth (~> 1.5)
+    - GTMAppAuth (~> 1.3)
+    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
+  - GTMAppAuth (1.3.1):
+    - AppAuth/Core (~> 1.6)
+    - GTMSessionFetcher/Core (< 3.0, >= 1.5)
+  - GTMSessionFetcher/Core (2.3.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
-  - GoogleSignIn (~> 6.0.1)
+  - GoogleSignIn (~> 6.2.0)
 
 SPEC REPOS:
   trunk:
@@ -35,13 +36,13 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  Capacitor: 92088387144015b95e369bd7840e8ef28b8fe9f3
-  CapacitorCordova: 624ae0d33d61b554eda6823da8ea6c3e5170f646
-  GoogleSignIn: 1b0c4ec33a6fe282f4fa35d8ac64263230ddaf36
-  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
-  GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
+  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
+  Capacitor: d3d4463573438b9fa65326d1f3549da6f4c21634
+  CapacitorCordova: b1fe6bf1f36974a8e4a9044b342d22d49c0996d6
+  GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
+  GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
+  GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
 
-PODFILE CHECKSUM: 0f3f70de2469d6ef87a4f55c3a96868777b79b2e
+PODFILE CHECKSUM: f37796f40e1c9a0233c6f7494f01210c0cedf4f7
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.12.1


### PR DESCRIPTION
GoogleSignIn-iOS 6.0 disabled requesting additional scopes in sign in. This plugin's current workaround results in a very weird UX (user gets prompted to sign in and immediately after signing in gets prompted for additional scopes) [VIDEO](https://github.com/google/GoogleSignIn-iOS/issues/23#issuecomment-933015131). 

GoogleSignIn-iOS 6.2 restores the functionality of requesting scopes at signIn, fixing the issue.
https://github.com/google/GoogleSignIn-iOS/issues/23#issuecomment-933015131)).