### PR TITLE
refactor: deprecate `displayName`, use `name` property (Android)

### DIFF
--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -113,6 +113,8 @@ public class GoogleAuth extends Plugin {
           user.put("idToken", account.getIdToken());
           user.put("authentication", authentication);
 
+          user.put("name", account.getDisplayName());
+          // Deprecated: Use `user` instead of `displayName`
           user.put("displayName", account.getDisplayName());
           user.put("email", account.getEmail());
           user.put("familyName", account.getFamilyName());

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,8 +9,11 @@ declare module '@capacitor/cli' {
 export interface User {
   id: string;
   email: string;
-
-  displayName: string;
+  /**
+   * @deprecated use `name` instead
+   */
+  displayName: string
+  name: string;
   familyName: string;
   givenName: string;
   imageUrl: string;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -10,7 +10,7 @@ export interface User {
   id: string;
   email: string;
 
-  name: string;
+  displayName: string;
   familyName: string;
   givenName: string;
   imageUrl: string;


### PR DESCRIPTION
Google SignIn result return "displayName" (Basically full name) but the User container property "name" which is never populated. 
Ref: https://github.com/CodetrixStudio/CapacitorGoogleAuth/blob/2b73c096f894ad27b5c0c06ca704d4c4c408d2d0/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java#L116 
![image](https://github.com/CodetrixStudio/CapacitorGoogleAuth/assets/20811782/4a813f2c-73b4-4636-89a6-25e736664caf)

closes https://github.com/CodetrixStudio/CapacitorGoogleAuth/issues/73