### PR TITLE
Replace deprecated usage of getConfig method on iOS

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -31,13 +31,11 @@ public class GoogleAuth: CAPPlugin {
         let defaultGrantedScopes = ["email", "profile", "openid"];
 
         // these are scopes we will need to request after sign in
-        additionalScopes = (getConfigValue("scopes") as? [String] ?? []).filter {
+        additionalScopes = (getConfig().getArray("scopes") as? [String] ?? []).filter {
             return !defaultGrantedScopes.contains($0);
         };
                 
-        if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshToken") as? Bool {
-            forceAuthCode = forceAuthCodeConfig;
-        }
+        forceAuthCode = getConfig().getBoolean("forceCodeForRefreshToken", false)
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleOpenUrl(_ :)), name: Notification.Name(Notification.Name.capacitorOpenURL.rawValue), object: nil);
     }
@@ -118,10 +116,10 @@ public class GoogleAuth: CAPPlugin {
     
     
     func getClientIdValue() -> String? {
-        if let clientId = getConfigValue("iosClientId") as? String {
+        if let clientId = getConfig().getString("iosClientId") {
             return clientId;
         }
-        else if let clientId = getConfigValue("clientId") as? String {
+        else if let clientId = getConfig().getString("clientId") {
             return clientId;
         }
         else if let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
@@ -133,7 +131,7 @@ public class GoogleAuth: CAPPlugin {
     }
     
     func getServerClientIdValue() -> String? {
-        if let serverClientId = getConfigValue("serverClientId") as? String {
+        if let serverClientId = getConfig().getString("serverClientId") {
             return serverClientId;
         }
         return nil;


### PR DESCRIPTION
Fixes #334 

Please review, I'm not familiar with Swift - but deprecation warnings do not show anymore