### PR TITLE
Improvement/bump gms google auth version

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ plugin first use `androidClientId` if not found use `clientId` if not found use 
 </resources>
 ```
 
+Changing Play Services Auth version (Optional) :
+
+This plugin uses `com.google.android.gms:play-services-auth:21.2.0` by default, you can override it providing `gmsPlayServicesAuthVersion` at `variables.gradle`
+
 **Refresh method**
 
 This method should be called when the app is initialized to establish if the user is currently logged in. If true, the method will return an accessToken, idToken and an empty refreshToken.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.6.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.5'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
+    gmsPlayServicesAuthVersion = project.hasProperty('gmsPlayServicesAuthVersion') ? rootProject.ext.gmsPlayServicesAuthVersion : '21.2.0'
 }
 
 buildscript {
@@ -57,5 +58,5 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation 'com.google.android.gms:play-services-auth:18.+'
+    implementation "com.google.android.gms:play-services-auth:$gmsPlayServicesAuthVersion"
 }

--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -80,6 +80,7 @@ public class GoogleAuth extends Plugin {
   public void signIn(PluginCall call) {
     if(googleSignInClient == null){
       rejectWithNullClientError(call);
+      return;
     }
     Intent signInIntent = googleSignInClient.getSignInIntent();
     startActivityForResult(call, signInIntent, "signInResult");
@@ -160,6 +161,7 @@ public class GoogleAuth extends Plugin {
   public void signOut(final PluginCall call) {
     if(googleSignInClient == null){
       rejectWithNullClientError(call);
+      return;
     }
     googleSignInClient.signOut()
       .addOnSuccessListener(getActivity(), new OnSuccessListener<Void>() {

--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -78,6 +78,9 @@ public class GoogleAuth extends Plugin {
 
   @PluginMethod()
   public void signIn(PluginCall call) {
+    if(googleSignInClient == null){
+      rejectWithNullClientError(call);
+    }
     Intent signInIntent = googleSignInClient.getSignInIntent();
     startActivityForResult(call, signInIntent, "signInResult");
   }
@@ -155,6 +158,9 @@ public class GoogleAuth extends Plugin {
 
   @PluginMethod()
   public void signOut(final PluginCall call) {
+    if(googleSignInClient == null){
+      rejectWithNullClientError(call);
+    }
     googleSignInClient.signOut()
       .addOnSuccessListener(getActivity(), new OnSuccessListener<Void>() {
         @Override
@@ -256,5 +262,9 @@ public class GoogleAuth extends Plugin {
     }
     reader.close();
     return sb.toString();
+  }
+
+  private void rejectWithNullClientError(final PluginCall call) {
+    call.reject("Google services are not ready. Please call initialize() first");
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "3.4.0-rc.1",
+  "version": "3.4.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codetrix-studio/capacitor-google-auth",
-      "version": "3.4.0-rc.1",
+      "version": "3.4.0-rc.4",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^6.0.0",


### PR DESCRIPTION
Seeing other folks resolve the 
below error by updating the google-play SDK version, I made a change that increases default version to latest and allows clients to override this setting.

`java.lang.RuntimeException: Unable to start activity ComponentInfo{com.XXXXX/com.google.android.gms.auth.api.signin.internal.SignInHubActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference`

https://github.com/firebase/firebase-android-sdk/issues/5768


Also, added a check if gapi initialized correctly using `initialize` method. 

As seen on issue #364, this also fixes crashes happens when `signIn` & `signOut` called before the initialization. 
Instead of crashing, the plugin is now able to reject the promise gracefully.
ref: https://github.com/react-native-google-signin/google-signin/blob/f5ef438aeda0c40f68082dc0b1bddc04bbd6298c/android/src/main/java/com/reactnativegooglesignin/RNGoogleSigninModule.java#L174

