### PR TITLE
Updating tsconfig to skip lib check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noUnusedParameters": true,
     "outDir": "dist/esm",
     "sourceMap": true,
+    "skipLibCheck": true,
     "target": "es2017"
   },
   "files": ["src/index.ts"]


### PR DESCRIPTION
This was a particular bug

In my environment I use [nx](https://nx.dev/) to orchestrate my monorepo and I'm using capacitor with [@nxext/capacitor](https://nxext.github.io/nx-extensions-ionic/docs/ionic-react/capacitor.html) for the capacitor

The particular problem I'm having is that my environment is already on typescript 5 and that caused conflicts, this is also related to the installation and that kind of thing.

If this PR can't be accepted for some reason, I can try to host this as a fork or something, but I think it would be nice to keep everything together