### PR TITLE
Update GoogleSignIn pod to 7.1.0

### DIFF
--- a/CodetrixStudioCapacitorGoogleAuth.podspec
+++ b/CodetrixStudioCapacitorGoogleAuth.podspec
@@ -10,6 +10,6 @@
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
-    s.dependency 'GoogleSignIn', '~> 6.2.4'
+    s.dependency 'GoogleSignIn', '~> 7.1.0'
     s.static_framework = true
   end


### PR DESCRIPTION
Updated the GoogleSignIn dependency to:

- include necessary privacy manifests
- ensure compatibility with newer Google MLKit based capacitor plugins (E.G. `@capacitor-mlkit/barcode-scanning`)

I don't know how to deal with `serverAuthCode`, this used to be a property on `GIDGoogleUser` objects but it has been removed and I don't see any replacement for it. Please let me know if you have suggestions on how to solve this, current solution seems far from ideal.